### PR TITLE
Zero element length crashes

### DIFF
--- a/Demo/BezierPlayground/UIBezierPath+SuperpowersDemo.swift
+++ b/Demo/BezierPlayground/UIBezierPath+SuperpowersDemo.swift
@@ -281,6 +281,10 @@ fileprivate struct BezierPathElement {
     self.controlPoints = controlPoints
     
     length = type.calculateLength(from: startPoint, to: endPoint, controlPoints: controlPoints)
+    
+    if length == 0 {
+      length = 0.001
+    }
   }
   
   

--- a/Demo/BezierPlayground/UIBezierPath+SuperpowersDemo.swift
+++ b/Demo/BezierPlayground/UIBezierPath+SuperpowersDemo.swift
@@ -271,7 +271,11 @@ fileprivate struct BezierPathElement {
   var pointsLookupTable: [CGPoint]?
   
   var lengthRange: ClosedRange<CGFloat>?
-  var length: CGFloat
+  
+  private let calculatedLength: CGFloat
+  var length: CGFloat {
+    return calculatedLength == 0 ? 1 : calculatedLength
+  }
   
   
   init(type: CGPathElementType, startPoint: CGPoint, endPoint: CGPoint, controlPoints: [CGPoint] = []) {
@@ -280,11 +284,7 @@ fileprivate struct BezierPathElement {
     self.endPoint = endPoint
     self.controlPoints = controlPoints
     
-    length = type.calculateLength(from: startPoint, to: endPoint, controlPoints: controlPoints)
-    
-    if length == 0 {
-      length = 0.001
-    }
+    calculatedLength = type.calculateLength(from: startPoint, to: endPoint, controlPoints: controlPoints)
   }
   
   

--- a/UIBezierPath+Superpowers.swift
+++ b/UIBezierPath+Superpowers.swift
@@ -227,7 +227,11 @@ fileprivate struct BezierPathElement {
   var pointsLookupTable: [CGPoint]?
   
   var lengthRange: ClosedRange<CGFloat>?
-  var length: CGFloat
+  
+  private let calculatedLength: CGFloat
+  var length: CGFloat {
+    return calculatedLength == 0 ? 1 : calculatedLength
+  }
   
   
   init(type: CGPathElementType, startPoint: CGPoint, endPoint: CGPoint, controlPoints: [CGPoint] = []) {
@@ -236,11 +240,7 @@ fileprivate struct BezierPathElement {
     self.endPoint = endPoint
     self.controlPoints = controlPoints
     
-    length = type.calculateLength(from: startPoint, to: endPoint, controlPoints: controlPoints)
-    
-    if length == 0 {
-      length = 0.001
-    }
+    calculatedLength = type.calculateLength(from: startPoint, to: endPoint, controlPoints: controlPoints)
   }
   
   

--- a/UIBezierPath+Superpowers.swift
+++ b/UIBezierPath+Superpowers.swift
@@ -237,6 +237,10 @@ fileprivate struct BezierPathElement {
     self.controlPoints = controlPoints
     
     length = type.calculateLength(from: startPoint, to: endPoint, controlPoints: controlPoints)
+    
+    if length == 0 {
+      length = 0.001
+    }
   }
   
   


### PR DESCRIPTION
Fixes issue: https://github.com/ImJCabus/UIBezierPath-Superpowers/issues/5

Most of the public API requires the user to pass a fraction parameter called `atFractionOfLength`. Internally, we use this fraction to retrieve the path element at the given fraction of the paths total length to do further calculations. Hence, there is really no way of accounting for zero length path elements without restructuring most of the library.

Nevertheless, users may create `UIBezierPath` instances composed of such elements and iOS will actually draw each "dot" in the path taking into account the provided `lineWidth`, `lineCap`, etc., so we need to do something about this.

To prevent crashes, we give _every_ path element a length. This means we can leave all calculations as is. Inherently "empty" elements will receive a fixed length value.

After some reasoning, we decided to set this fixed value to `1`. It's a reasonable default value which should represent "dots" in the path quite well.

If there was any possibility we could access path drawing parameters, we could actually provide a much more fitting value. The properties on `UIBezierPath` (`lineWidth`, `lineCapStyle`) are no good, because `UIBezierPath` is frequently used in conjunction with `CAShapeLayer` and `UIKit` (`CoreGraphics` actually) will use the properties provided there to draw the path and ignore properties of the path itself.

This is the best and swiftest (badum tss) fix I can think of right now. Maybe in the future it's worth revisiting this, but for the moment I thing we're good.